### PR TITLE
Build fix only

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ cache:
 #build: off
 
 platform:
-- x86
 - x64
 
 environment:
@@ -13,9 +12,9 @@ environment:
     STACK_ROOT: "c:\\sr"
 
 install:
-- if %PLATFORM%==x86 (curl -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386) else (curl -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64)
+- curl -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe
-- stack --resolver=lts-9.21 setup > nul
+- stack --resolver=lts-20.26 setup > nul
 - ps: |
     choco --no-progress install wixtoolset -version 3.11.1 -y
     $env:Path += ";${env:ProgramFiles}\WiX Toolset v3.11\bin"
@@ -24,16 +23,16 @@ install:
 build_script:
 # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
 # descriptor
-- echo "" | stack --resolver=lts-9.21 --no-terminal test --bench --no-run-benchmarks --flag CPL:Haskeline --flag CPL:-Readline
+- echo "" | stack --resolver=lts-20.26 --no-terminal test --bench --no-run-benchmarks --flag CPL:Haskeline --flag CPL:-Readline
 
 after_test:
-- ps: cp "$(./stack --resolver=lts-9.21 path --local-install-root)/bin/cpl.exe" cpl.exe
+- ps: cp "$(./stack --resolver=lts-20.26 path --local-install-root)/bin/cpl.exe" cpl.exe
 - cmd: |
    cd windows
    echo Creating msi...
-   ..\stack --resolver=lts-9.21 runhaskell --package turtle build_msi.hs
+   ..\stack --resolver=lts-20.26 runhaskell --package turtle build_msi.hs
    echo Creating zip...
-   ..\stack --resolver=lts-9.21 runhaskell --package turtle build_zip.hs
+   ..\stack --resolver=lts-20.26 runhaskell --package turtle build_zip.hs
    cd ..
 
 artifacts:

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -30,6 +30,7 @@ import Data.Version
 import System.Environment
 import System.Exit
 import System.IO
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.State.Strict -- haskeline's MonadException requries strict version
 import System.Console.GetOpt

--- a/src/Simp.hs
+++ b/src/Simp.hs
@@ -26,6 +26,7 @@ import qualified CDT
 import qualified FE
 import Exp (Id)
 import Type
+import Control.Monad
 import Control.Monad.RWS
 import Data.Array
 import qualified Data.Map as Map

--- a/src/Typing.hs
+++ b/src/Typing.hs
@@ -25,6 +25,7 @@ import qualified Exp as E
 
 import Data.List (nub)
 import Control.Applicative
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.RWS
 import qualified Data.Map as Map

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-10.5
+resolver: lts-20.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
- on recent ghc, may need to import Control.Monad to use forM and so on.
- version up  of stack lts, since it was too old.