### PR TITLE
Use "cabal list-bin" instead of "find" to locate cpl.wasm

### DIFF
--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -65,7 +65,7 @@ echo ""
 echo "Locating WASM binary..."
 
 # Find the compiled WASM binary
-WASM_BIN=$(find dist-newstyle -name "cpl.wasm" -type f | grep wasm32-wasi | head -n1)
+WASM_BIN=$(wasm32-wasi-cabal list-bin cpl)
 
 if [ -z "$WASM_BIN" ]; then
     echo "Error: Could not find compiled WASM binary"


### PR DESCRIPTION
This is because if build results from an older version remain (due to caching, etc.), `find` may locate them instead.