### PR TITLE
Migrate from Text.ParserCombinators.Parsec to Text.Parsec

### DIFF
--- a/src/CDTParser.hs
+++ b/src/CDTParser.hs
@@ -24,7 +24,8 @@ import Type (GenType(..))
 import CDT
 import ParserUtils
 
-import Text.ParserCombinators.Parsec
+import Text.Parsec hiding (string')
+import Text.Parsec.String (Parser)
 import Control.Monad
 import Data.List
 

--- a/src/CPLSystem.hs
+++ b/src/CPLSystem.hs
@@ -42,7 +42,7 @@ import qualified Subst
 import Control.Monad
 import Data.Maybe
 import Data.List
-import Text.ParserCombinators.Parsec
+import Text.Parsec
 import qualified Data.Map as Map
 
 type CDTEnv = [CDT]

--- a/src/ExpParser.hs
+++ b/src/ExpParser.hs
@@ -25,7 +25,8 @@ import ParserUtils
 import Prelude hiding (exp)
 import Control.Monad
 import Control.Monad.Except
-import Text.ParserCombinators.Parsec
+import Text.Parsec hiding (string')
+import Text.Parsec.String (Parser)
 import Data.List (find)
 import Data.Maybe
 import qualified Data.Map as Map

--- a/src/ParserUtils.hs
+++ b/src/ParserUtils.hs
@@ -6,7 +6,8 @@ module ParserUtils
     , ident
     ) where
 
-import Text.ParserCombinators.Parsec
+import Text.Parsec hiding (string')
+import Text.Parsec.String (Parser)
 import Data.Char
 
 type Ident = String


### PR DESCRIPTION
## Summary
- Update parser imports to use modern `Text.Parsec` module hierarchy instead of deprecated `Text.ParserCombinators.Parsec`
- Add `hiding (string')` to avoid name collision with `ParserUtils.string'`
- Import `Parser` type from `Text.Parsec.String` where needed

## Test plan
- [x] `stack build` succeeds
- [x] `stack test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)