### PR TITLE
Remove readline support and simplify console abstraction

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -8,6 +8,7 @@
 * Add tutorials both in English and Japanese
 * Accept `id` as a synonym for `I` (identity morphism)
 * Allow the omission of the `is` keyword in data type definitions
+* Remove readline support (the `Readline` cabal flag and `USE_READLINE_PACKAGE` code path)
 * Drop support for GHC <9.2 (base <4.16)
 
 0.1.0 (2025-10-29)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,6 @@ stack test
 
 ### Build Flags
 
-- `-fReadline`: Enable readline support (default: True)
 - `-fHaskeline`: Enable haskeline support (default: True)
 - `-fLinuxStatic`: Build statically linked binaries on Linux
 - `-fWeb`: Build for browser environment with WebAssembly + JavaScript FFI (default: False)
@@ -57,13 +56,13 @@ stack test
 
 **Integration:**
 - `CPLSystem.hs` - System environment (`System` record) integrating parser, type checker, and simplifier
-- `Main.hs` - REPL with command dispatch, file loading, and console abstraction (readline/haskeline/plain)
+- `Main.hs` - REPL with command dispatch, file loading, and console abstraction (haskeline/plain)
 
 ### Key Design Patterns
 
 - **Monad Stack**: `UI a = ExceptT String (StateT UIState Console) a` for error handling and state
 - **Variance Lattice**: Four levels (Covariance, Contravariance, FixedVariance, FreeVariance) critical for categorical type soundness
-- **CPP Console Abstraction**: Conditional compilation for readline/haskeline/plain I/O
+- **CPP Console Abstraction**: Conditional compilation for haskeline/plain I/O
 
 ## REPL Commands
 

--- a/CPL.cabal
+++ b/CPL.cabal
@@ -62,10 +62,6 @@ source-repository head
   type:     git
   location: git://github.com/msakai/cpl.git
 
-Flag Readline
-  Description: Use Readline
-  Default: True
-
 Flag Haskeline
   Description: Use Haskeline
   Default: True
@@ -99,12 +95,8 @@ Executable cpl
     if impl(ghc >= 9.10)
       Other-Extensions: JavaScriptFFI
   else
-    if flag(Readline)
-      CPP-Options: "-DUSE_READLINE_PACKAGE"
-      Build-Depends: readline
-    else
-      if flag(Haskeline)
-        CPP-Options: "-DUSE_HASKELINE_PACKAGE"
-        Build-Depends: haskeline
+    if flag(Haskeline)
+      CPP-Options: "-DUSE_HASKELINE_PACKAGE"
+      Build-Depends: haskeline
   if flag(LinuxStatic)
     GHC-Options: -static -optl-static -optl-pthread

--- a/README.markdown
+++ b/README.markdown
@@ -45,8 +45,8 @@ $ cabal build
 $ cabal install
 ```
 
-If you want to compile with readline or haskeline, add `-fReadline` or
-`-fHaskeline` respectively to the configure command.
+If you want to compile with haskeline, add `-fHaskeline` to the configure
+command.
 
 Alternatively, you can use Stack:
 

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -62,7 +62,7 @@ echo ""
 
 echo ""
 echo "Configuring CPL for WebAssembly..."
-wasm32-wasi-cabal configure -fWeb -f-Readline -f-Haskeline
+wasm32-wasi-cabal configure -fWeb -f-Haskeline
 
 echo ""
 echo "Building CPL..."

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -43,9 +43,6 @@ import System.Console.GetOpt
 #if defined(USE_WEB_BACKEND)
 import GHC.Wasm.Prim (JSString (..), toJSString, fromJSString, JSException (..), JSVal)
 import Control.Exception (evaluate)
-#elif defined(USE_READLINE_PACKAGE)
-import qualified System.Console.SimpleLineEditor as SLE
-import Control.Exception (bracket)
 #elif defined(USE_HASKELINE_PACKAGE)
 import qualified System.Console.Haskeline as Haskeline
 #else
@@ -97,19 +94,6 @@ runConsole m = Haskeline.runInputT Haskeline.defaultSettings m
 
 readLine' :: String -> Console String
 readLine' prompt = liftM (fromMaybe "") $ Haskeline.getInputLine prompt
-
-printLine' :: String -> Console ()
-printLine' s = liftIO $ putStrLn $ s
-
-#elif defined(USE_READLINE_PACKAGE)
-
-type Console = IO
-
-runConsole :: Console a -> IO a
-runConsole m = bracket SLE.initialise (const SLE.restore) (const m)
-
-readLine' :: String -> Console String
-readLine' prompt = liftM (fromMaybe "") $ SLE.getLineEdited prompt
 
 printLine' :: String -> Console ()
 printLine' s = liftIO $ putStrLn $ s

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,9 +42,7 @@ packages:
 # extra-deps: []
 
 # Override default flag values for local packages and extra-deps
-flags:
-  CPL:
-    readline: false
+flags: {}
 
 # Extra package databases containing global packages
 # extra-package-dbs: []

--- a/web/README.md
+++ b/web/README.md
@@ -82,7 +82,7 @@ This provides `wasm32-wasi-ghc` and `wasm32-wasi-cabal` in `PATH`.
 Build configuration:
 
 ```bash
-wasm32-wasi-cabal configure -fWeb -f-Readline -f-Haskeline
+wasm32-wasi-cabal configure -fWeb -f-Haskeline
 ```
 
 To clean and rebuild:
@@ -155,8 +155,6 @@ The Haskell code uses CPP macros to conditionally compile different Console impl
   -- JavaScript FFI implementation (GHC.Wasm.Prim / JSString)
 #elif defined(USE_HASKELINE_PACKAGE)
   -- Haskeline implementation
-#elif defined(USE_READLINE_PACKAGE)
-  -- Readline implementation
 #else
   -- Plain IO implementation
 #endif
@@ -280,7 +278,7 @@ Two parallel build systems are maintained:
 1. **Stack** (for native builds)
    - Uses `stack.yaml`
    - Default for development
-   - Supports readline/haskeline
+   - Supports haskeline
 
 2. **Cabal** (for both native and WASM builds)
    - Uses `CPL.cabal` with flags


### PR DESCRIPTION
## Summary
This PR removes readline support from the CPL project, simplifying the console abstraction layer to support only haskeline and plain I/O backends. The `Readline` cabal flag and all associated `USE_READLINE_PACKAGE` code paths have been eliminated.

## Key Changes
- **CPL.cabal**: Removed the `Readline` flag definition and simplified the conditional build logic to only check for haskeline support
- **src/Main.hs**: Removed the readline-specific imports and console implementation (SimpleLineEditor)
- **Documentation**: Updated CHANGELOG, README, CLAUDE.md, and web/README.md to remove references to readline support
- **Build scripts**: Updated `scripts/build-wasm.sh` and `stack.yaml` to remove readline flag configuration
- **Console abstraction**: Simplified CPP conditional compilation from three backends (readline/haskeline/plain) to two (haskeline/plain)

## Implementation Details
The console abstraction in `Main.hs` now uses a simpler conditional compilation structure:
1. WebAssembly backend (USE_WEB_BACKEND) - JavaScript FFI
2. Haskeline backend (USE_HASKELINE_PACKAGE) - Full-featured line editing
3. Plain I/O backend (fallback) - Basic stdin/stdout

This reduces maintenance burden while preserving the primary line-editing functionality through haskeline, which is the default and recommended option.

https://claude.ai/code/session_01DYsfAWteBXCsfkeMHjgVsN