### PR TITLE
Read files as UTF-8 in load command regardless of system locale

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -371,7 +371,10 @@ cmdLoad s =
                     f [] tmp       = [tmp]
 #else
 cmdLoad s =
-    do result <- liftIO $ try $ readFile filename
+    do result <- liftIO $ try $ do
+         h <- openFile filename ReadMode
+         hSetEncoding h utf8
+         hGetContents h
        contents <-
          case result of
            Left (e :: SomeException) -> throwError (show e)


### PR DESCRIPTION
Changed cmdLoad to explicitly open files with UTF-8 encoding instead of
using readFile which depends on the system locale setting. This ensures
CPL source files with Unicode characters (e.g., ∘ for composition) are
read correctly on any system.

https://claude.ai/code/session_01UfCSVPHob2bFnTcz2C1G7H