### PR TITLE
Add Homebrew installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,22 @@ Try CPL directly in your browser:
 
 No installation required! Works on Chrome, Firefox, Safari, and Edge.
 
-### Option 2: Build from Source 🔧
+### Option 2: Homebrew (macOS/Linux) 🍺
+
+Install CPL using [Homebrew](https://brew.sh/):
+
+```bash
+$ brew install msakai/tap/cpl
+```
+
+Alternatively, you can tap the repository first:
+
+```bash
+$ brew tap msakai/tap
+$ brew install cpl
+```
+
+### Option 3: Build from Source 🔧
 
 **Supported GHC versions:** >=9.2
 


### PR DESCRIPTION
## Summary
- Add Homebrew installation option to README.md
- Document `msakai/tap` tap with `brew install msakai/tap/cpl` command
- Reorder existing options (WebAssembly → Option 1, Homebrew → Option 2, Build from Source → Option 3)

## Test plan
- [x] Verify Homebrew installation works with `brew install msakai/tap/cpl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)