### PR TITLE
add OGP meta tags to live demo page

### DIFF
--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -113,6 +113,8 @@ cp "$PROJECT_ROOT/web/apple-touch-icon.png" "$OUTPUT_DIR/"
 cp "$PROJECT_ROOT/web/icon-192x192.png" "$OUTPUT_DIR/"
 cp "$PROJECT_ROOT/web/icon-512x512.png" "$OUTPUT_DIR/"
 cp "$PROJECT_ROOT/web/manifest.json" "$OUTPUT_DIR/"
+mkdir -p "$OUTPUT_DIR/images"
+cp "$PROJECT_ROOT/images/screenshot.png" "$OUTPUT_DIR/images/"
 echo "✓ Copied web files"
 
 # Get file size
@@ -138,7 +140,7 @@ echo ""
 echo "Checking output files..."
 MISSING_FILES=0
 
-for f in index.html cpl-terminal.js cpl.wasm cpl.js samples.js favicon.ico favicon-16x16.png favicon-32x32.png apple-touch-icon.png icon-192x192.png icon-512x512.png manifest.json; do
+for f in index.html cpl-terminal.js cpl.wasm cpl.js samples.js favicon.ico favicon-16x16.png favicon-32x32.png apple-touch-icon.png icon-192x192.png icon-512x512.png manifest.json images/screenshot.png; do
     if [ -f "$OUTPUT_DIR/$f" ]; then
         echo "  ✓ $f"
     else

--- a/web/index.html
+++ b/web/index.html
@@ -10,6 +10,17 @@
   <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#4ec9b0">
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://msakai.github.io/cpl/">
+  <meta property="og:title" content="CPL - Categorical Programming Language">
+  <meta property="og:description" content="Browser-based interpreter for Tatsuya Hagino's Categorical Programming Language, powered by WebAssembly.">
+  <meta property="og:image" content="https://msakai.github.io/cpl/images/screenshot.png">
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="CPL - Categorical Programming Language">
+  <meta name="twitter:description" content="Browser-based interpreter for Tatsuya Hagino's Categorical Programming Language, powered by WebAssembly.">
+  <meta name="twitter:image" content="https://msakai.github.io/cpl/images/screenshot.png">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
   <style>
     :root {


### PR DESCRIPTION
Add Open Graph and Twitter Card meta tags to web/index.html so that
the page shows a rich preview (title, description, screenshot) when
shared on social media. Also update build-wasm.sh to copy
images/screenshot.png into _site/ for GitHub Pages deployment.

https://claude.ai/code/session_017wicgaWeRb7tAuqDtHGEXm