### PR TITLE
Use modal dialog for edit command in web version

### DIFF
--- a/web/cpl-terminal.js
+++ b/web/cpl-terminal.js
@@ -204,6 +204,58 @@ window.terminal_readLine = async (jsVal) => {
   return result;
 };
 
+/**
+ * Open a modal dialog with a textarea for multi-line editing.
+ * Returns a Promise that resolves with the entered text, or rejects on cancel.
+ */
+window.terminal_editModal = () => {
+  return new Promise((resolve, reject) => {
+    const overlay = document.getElementById('edit-modal-overlay');
+    const textarea = document.getElementById('edit-modal-textarea');
+    const okBtn = document.getElementById('edit-modal-ok');
+    const cancelBtn = document.getElementById('edit-modal-cancel');
+
+    textarea.value = '';
+    overlay.classList.add('active');
+    textarea.focus();
+
+    function cleanup() {
+      overlay.classList.remove('active');
+      okBtn.removeEventListener('click', onOk);
+      cancelBtn.removeEventListener('click', onCancel);
+      textarea.removeEventListener('keydown', onKeydown);
+    }
+
+    function onOk() {
+      const text = textarea.value;
+      cleanup();
+      resolve(text);
+    }
+
+    function onCancel() {
+      cleanup();
+      reject(new Error('edit cancelled'));
+    }
+
+    function onKeydown(e) {
+      // Ctrl+Enter or Cmd+Enter to submit
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        onOk();
+      }
+      // Escape to cancel
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    }
+
+    okBtn.addEventListener('click', onOk);
+    cancelBtn.addEventListener('click', onCancel);
+    textarea.addEventListener('keydown', onKeydown);
+  });
+};
+
 window.terminal_loadFile = async (jsVal) => {
   const filename = String(jsVal).trim();
 

--- a/web/index.html
+++ b/web/index.html
@@ -177,6 +177,94 @@
       color: var(--color-text-subtle);
       font-size: 0.9rem;
     }
+
+    /* Edit modal dialog */
+    #edit-modal-overlay {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.6);
+      z-index: 1000;
+      justify-content: center;
+      align-items: center;
+    }
+
+    #edit-modal-overlay.active {
+      display: flex;
+    }
+
+    #edit-modal {
+      background: var(--color-bg-elevated);
+      border: 1px solid var(--color-primary);
+      border-radius: 8px;
+      padding: 1.5rem;
+      width: 90%;
+      max-width: 700px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+    }
+
+    #edit-modal h2 {
+      margin: 0 0 1rem 0;
+      font-size: 1.1rem;
+      color: var(--color-primary);
+    }
+
+    #edit-modal textarea {
+      width: 100%;
+      height: 250px;
+      background: var(--color-bg);
+      color: var(--color-text);
+      border: 1px solid var(--color-border);
+      border-radius: 4px;
+      padding: 0.75rem;
+      font-family: Menlo, Monaco, 'Courier New', monospace;
+      font-size: 14px;
+      resize: vertical;
+      line-height: 1.5;
+    }
+
+    #edit-modal textarea:focus {
+      outline: none;
+      border-color: var(--color-primary);
+    }
+
+    #edit-modal .modal-buttons {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.75rem;
+      margin-top: 1rem;
+    }
+
+    #edit-modal button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--color-border);
+      border-radius: 4px;
+      font-size: 0.9rem;
+      cursor: pointer;
+      font-family: inherit;
+    }
+
+    #edit-modal-ok {
+      background: var(--color-primary);
+      color: var(--color-bg);
+      border-color: var(--color-primary);
+    }
+
+    #edit-modal-ok:hover {
+      opacity: 0.9;
+    }
+
+    #edit-modal-cancel {
+      background: transparent;
+      color: var(--color-text);
+    }
+
+    #edit-modal-cancel:hover {
+      background: var(--color-border);
+    }
   </style>
 </head>
 <body>
@@ -220,6 +308,17 @@
         <a href="https://github.com/msakai/cpl" target="_blank">GitHub Repository</a>
       </p>
     </footer>
+  </div>
+
+  <div id="edit-modal-overlay">
+    <div id="edit-modal">
+      <h2>Edit</h2>
+      <textarea id="edit-modal-textarea" placeholder="Enter commands here..." spellcheck="false"></textarea>
+      <div class="modal-buttons">
+        <button id="edit-modal-cancel" type="button">Cancel</button>
+        <button id="edit-modal-ok" type="button">OK</button>
+      </div>
+    </div>
   </div>
 
   <script type="module" src="cpl-terminal.js"></script>


### PR DESCRIPTION
Instead of line-by-line terminal input, the web version's edit command
now opens a modal dialog with a textarea for multi-line editing. The
input is displayed in the terminal with "| " prefix lines after
submission, and a semicolon is appended if missing.

Keyboard shortcuts: Ctrl+Enter to submit, Escape to cancel.

https://claude.ai/code/session_01QVXkv8rxD49QVoYQQRTReX